### PR TITLE
Update cloudflareddns.sh

### DIFF
--- a/cloudflareddns.sh
+++ b/cloudflareddns.sh
@@ -14,18 +14,22 @@ hostname="$3"
 ipAddr="$4"
 
 #Fetch and filter IPv6, if Synology won't provide it
-ip6fetch=$(ip -6 addr show eth0 | grep -oP "$ipv6Regex")
-ip6Addr=$(if [ -z "$ip6fetch" ]; then echo ""; else echo "${ip6fetch:0:$((${#ip6fetch})) - 7}"; fi) # in case of NULL, echo NULL
-recType6="AAAA"
+if [[ $ipv6 = "true" ]]; then
+	ip6fetch=$(ip -6 addr show eth0 | grep -oP "$ipv6Regex")
+	ip6Addr=$(if [ -z "$ip6fetch" ]; then echo ""; else echo "${ip6fetch:0:$((${#ip6fetch})) - 7}"; fi) # in case of NULL, echo NULL
+	recType6="AAAA"
 
-if [[ -z "$ip6Addr" ]]; then
-	ipv6="false"; 	# if only ipv4 is available
-fi
-if [[ $ipAddr =~ $ipv4Regex ]]; then
-    recordType="A";
+	if [[ -z "$ip6Addr" ]]; then
+		ipv6="false"; 	# if only ipv4 is available
+	fi
+	if [[ $ipAddr =~ $ipv4Regex ]]; then
+		recordType="A";
+	else
+		recordType="AAAA";
+		ipv6="false"; # because, Synology had provided the IPv6
+	fi
 else
-	recordType="AAAA";
-	ipv6="false"; # because, Synology had provided the IPv6
+	recordType="A";
 fi
 
 # Cloudflare API-Calls for listing entries


### PR DESCRIPTION
Added conditional to skip IPv6 address fetching if $ipv6 isn't set to true. Resolved an issue on my DSM where script could not determine record type and failed silently, even with ipv6 set to false.